### PR TITLE
If using luckperms only check for directly inherited groups when syncing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     annotationProcessor 'org.spongepowered:spongeapi:7.2.0-SNAPSHOT'
     compile 'com.github.Eufranio:MagiBridge:v2.9.3'
     shadow 'com.github.Eufranio:StorageUtils:2.2'
+    compile 'net.luckperms:api:5.0'
 }
 
 repositories {


### PR DESCRIPTION
When using LuckPerms tracks where groups inherit the one before them, the Plugin will apply all roles before the one the Player actually inherits directly. This commit mitigates that problem.